### PR TITLE
🍱 asset: 추가 Assets - Colors (#6)

### DIFF
--- a/Jihwaja/Assets.xcassets/Colors/Contents.json
+++ b/Jihwaja/Assets.xcassets/Colors/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Jihwaja/Assets.xcassets/Colors/gray.colorset/Contents.json
+++ b/Jihwaja/Assets.xcassets/Colors/gray.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.902",
+          "green" : "0.894",
+          "red" : "0.894"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Jihwaja/Assets.xcassets/Colors/gray_button.colorset/Contents.json
+++ b/Jihwaja/Assets.xcassets/Colors/gray_button.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.686",
+          "green" : "0.686",
+          "red" : "0.686"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Jihwaja/Assets.xcassets/Colors/gray_text.colorset/Contents.json
+++ b/Jihwaja/Assets.xcassets/Colors/gray_text.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.518",
+          "green" : "0.518",
+          "red" : "0.518"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Jihwaja/Assets.xcassets/Colors/green.colorset/Contents.json
+++ b/Jihwaja/Assets.xcassets/Colors/green.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.490",
+          "green" : "0.702",
+          "red" : "0.329"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Jihwaja/Assets.xcassets/Colors/red.colorset/Contents.json
+++ b/Jihwaja/Assets.xcassets/Colors/red.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.031",
+          "green" : "0.039",
+          "red" : "0.710"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## 이슈번호 #6

***

## 작업 주제
- Assets 폴더에 팀 컬러 추가
***

## 작업 내용
- gray_text
- gray_button
- green
- gray
***

## ETC
- black, white는 xcode의 기본 컬러와 동일하여 추가하지 않음