### PR TITLE
Feat/25 navigation stack

### DIFF
--- a/Jihwaja/Views/MainView.swift
+++ b/Jihwaja/Views/MainView.swift
@@ -80,10 +80,8 @@ struct MainView: View {
                                         print(store.jihwaja.isFlipped[index])
                                     }
                                     .rotation3DEffect(.init(degrees: store.jihwaja.isFlipped[index] != false ? 180 : 0), axis: (x: 0.0, y: 1.0, z: 0.0), anchor: .center, anchorZ: 0.0, perspective: 0.2)
-                                    
                                 }
                             )
-                            
                         } // ForEach
                     }
                 }
@@ -101,10 +99,6 @@ struct MainView: View {
                 
             } //VStack
             .frame(width: getWidth() * 0.76)
-//            .onChange(of: scenePhase) { phase in
-//                        if phase == .inactive { saveAction() }
-//                    }
-            
         } //NavigationView
     } // Body
     
@@ -138,10 +132,7 @@ struct MainView: View {
         default:
             return AnyView(EmptyView())
         }
-
     }
-    
- 
 } // View
 
 extension View {
@@ -158,7 +149,6 @@ extension View {
 
 struct MainView_Previews: PreviewProvider {
     static var previews: some View {
-        //MainView(saveAction: {})
         MainView()
     }
 }

--- a/Jihwaja/Views/MainView.swift
+++ b/Jihwaja/Views/MainView.swift
@@ -69,7 +69,15 @@ struct MainView: View {
                                             .frame(width: getWidth() * 0.18, height: getWidth() * 0.24)
                                             .cornerRadius(7)
                                             .flipped()
-                                            .opacity(store.jihwaja.isFlipped[index] != false ? 1 : 0)
+                                            .opacity(store.jihwaja.isFlipped[index] ? 1 : 0)
+                                    }
+                                    .onAppear{
+                                        if store.jihwaja.isCompleted[index] == true && store.jihwaja.isFlipped[index] == false {
+                                            withAnimation(Animation.easeInOut(duration: 0.5)){
+                                                store.jihwaja.isFlipped[index] = true
+                                            }
+                                        }
+                                        print(store.jihwaja.isFlipped[index])
                                     }
                                     .rotation3DEffect(.init(degrees: store.jihwaja.isFlipped[index] != false ? 180 : 0), axis: (x: 0.0, y: 1.0, z: 0.0), anchor: .center, anchorZ: 0.0, perspective: 0.2)
                                     


### PR DESCRIPTION
## 이슈번호 #25

***

## 작업 주제
- 전체 Flow: 애니메이션

***

## 작업 내용
- 답변이 완료됨에 따라 MainView 보여질 때 화투 뒤집히는 애니메이션 활성화
- 한번 뒤집힌 것은 다시 MainView가 보여져도 뒤집히지 않습니다.

***

## ETC
- 뒤집히는 소리 추후에 추가할 예정
