### PR TITLE
Fix/10 q10View #10

### DIFF
--- a/Jihwaja/Views/Questions/QuestionView10.swift
+++ b/Jihwaja/Views/Questions/QuestionView10.swift
@@ -1,19 +1,125 @@
-//
-//  QuestionView10.swift
-//  Jihwaja
-//
-//  Created by Minkyung Kim on 2023/05/02.
-//
-
 import SwiftUI
 
+
+// edit it later
+let IMAGE_WIDTHS: CGFloat = 150
+let IMAGE_HEIGHTS: CGFloat = 200
+
+
 struct QuestionView10: View {
+    
+    
+    @State private var isActiveQ10 = false
+    
+    // stage 0: 8강
+    // stage 1: 4강
+    // stage 2: 결승
+    // stage 3: 우승
+    @State var stage: Int = 0
+    // selected card name
+    @State var selected: [String]! = []
+    // default card list for each stage
+    @State var not_cards = ["cardDesign00", "cardDesign01", "cardDesign02", "cardDesign03","cardDesign04", "cardDesign05", "cardDesign06", "cardDesign07", "", ""]
+    
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        
+        NavigationView{
+            
+            VStack {
+                
+                ScrollView {
+                    
+                    QuestionView(question: "💁‍♂️ 두 가지 선택지 중 곽애숙씨가 더 선호하는 취미를 골라주세요")
+                    
+                    
+                    VStack {
+                        Text(stage == 0 ? "8 강" : stage == 1 ? "4강" : stage == 2 ? "결승" : "🥳 우승! 🎉")
+                            .font(.system(size: 40, weight: .bold, design: .rounded))
+                            .foregroundColor(.green)
+                        
+                        if stage == 3 {
+                            
+                            HStack() {
+                                    ImageView(imageName: selected[0])
+                            }
+                            .frame(width: IMAGE_WIDTHS + 50, height: IMAGE_HEIGHTS + 50)
+                        }
+                        else {
+                            
+                            HStack() {
+                                // left side is cliked
+                                Button(action: {
+                                    selected.append(not_cards.removeFirst())
+                                    not_cards.removeFirst()
+                                }) {
+                                    ImageView(imageName: not_cards[0])
+                                }
+                                
+                                // right side is cliked
+                                Button(action: {
+                                    selected.append(not_cards.remove(at: 1))
+                                    not_cards.removeFirst()
+                                    
+                                }) {
+                                    ImageView(imageName: not_cards[1])
+                                }
+                            }
+                        }
+                    }
+                    .padding()
+                    
+                }
+                .onChange(of: selected.count) { newValue in
+                    if newValue == 4 {
+                        stage += 1
+                        not_cards = selected + ["", ""]
+                        selected = []
+                    }
+                    else if newValue == 2 && stage == 1 {
+                        stage += 1
+                        not_cards = selected + ["", ""]
+                        selected = []
+                    }
+                    else if newValue == 1 && stage == 2 {
+                        stage += 1
+                    }
+                }
+                .onChange(of: stage) { newValue in
+                    if newValue == 3 {
+                        isActiveQ10 = true
+                    }
+                }
+                
+                StoreButtonView(isActive: isActiveQ10)
+                    
+            }
+        }
+    }
+    
+    
+    
+}
+
+
+
+
+
+struct ImageView: View {
+    var imageName: String
+    
+    var body: some View {
+            Image("\(imageName)")
+            .resizable()
+            .scaledToFit()
+            .mask {
+                RoundedRectangle(cornerRadius: 22)
+                .frame(width: IMAGE_WIDTHS, height: IMAGE_HEIGHTS)
+            }
     }
 }
 
-struct QuestionView10_Previews: PreviewProvider {
+struct Question10_Previews: PreviewProvider {
     static var previews: some View {
         QuestionView10()
     }


### PR DESCRIPTION
## 이슈번호 #10

***

## 작업 주제
- #10 Q10View 구현

***

## 작업 내용
-  8개의 카드와 글씨 (카드 안에는 일러스트)
-  2개 카드 중 1개 카드 누르면 선택받고 저장하기
-  8개 중 2개씩 나와서 8강 진행
-  선택받은 4개 중 2개씩 4강 진행
-  마지막 2개로 결승전 진행
-  한개 선택할 시 애니메이션 : 선택안된거 투명도 0으로 낮추기
-  8강, 4강, 결승전 진행상황 알려주기
-  최종 결과 저장하기


***

## ETC

- [ ] 모달뷰 : 팝업창 1, 2를 통합하여 Gif로 구현
- [ ] 일러스트 추가
- [ ] 주석 추가
- [ ] 이미지 가로 세로 비율로 변경

- [ ] 여유 있을 시 에니메이션 추가

선택된 카드를 저장하는 배열
데이터를 낭비하지 않도록 최소의 배열을 사용하면 좋을 것 같습니다.


Q10 브랜치 오류 문제로 삭제 후 feat -> bug 로 재생성 했습니다.
추가적으로, 저장버튼 수정해서 다시 올립니다.