### PR TITLE
Bug/13 q2 view

### DIFF
--- a/Jihwaja/Views/Questions/QuestionView02.swift
+++ b/Jihwaja/Views/Questions/QuestionView02.swift
@@ -43,6 +43,7 @@ struct QuestionView02: View {
                 step: 1
             )
             .padding()
+            .frame(width: 320)
             .onChange(of: yes) { _ in
                 
                 // Slider 값이 변경되면 버튼 Activate


### PR DESCRIPTION
## 이슈번호 #13

***

## 작업 주제
- #13 Q2 슬라이더 바 수정

***

## 작업 내용
- Q2에 있는 슬라이더 바의 너비를 줄였습니다. 

***

## ETC
- 슬라이더 바의 너비를 줄인 이유는 슬라이더 바가 길어 드래그할 때 전으로 돌아가는 동작과 유사하게 인식해 동작을 수행하는데 오류가 있기 때문입니다. 
- frame(width: 320)로 조절했습니다. 
